### PR TITLE
fix: replaced deprecated accentTextTheme with textTheme.labelLarge

### DIFF
--- a/lib/ui/pages/issue_detail.dart
+++ b/lib/ui/pages/issue_detail.dart
@@ -23,7 +23,8 @@ class IssueDetailPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final TextTheme textTheme = Theme.of(context).textTheme;
     final buttonColor = Theme.of(context).colorScheme.secondary;
-    final buttonTextColor = Theme.of(context).accentTextTheme.labelLarge?.color;
+    //final buttonTextColor = Theme.of(context).accentTextTheme.labelLarge?.color;
+    final buttonTextColor = Theme.of(context).textTheme.labelLarge?.color;
 
     var url = issue.url;
 


### PR DESCRIPTION
Replaced deprecated accentTextTheme.labelLarge with textTheme.labelLarge to make the code compatible with latest Flutter SDK.