### PR TITLE
refactor: use linkServiceProvider in AboutPage to remove url_launcher…

### DIFF
--- a/lib/ui/pages/about.dart
+++ b/lib/ui/pages/about.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../services/link.dart';
 
-class AboutPage extends StatelessWidget {
+class AboutPage extends ConsumerWidget {
   const AboutPage({super.key});
 
   static Route<dynamic> route() {
@@ -11,7 +12,7 @@ class AboutPage extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     var theme = Theme.of(context);
     var textTheme = theme.textTheme;
     const contactInfo = [
@@ -73,13 +74,7 @@ class AboutPage extends StatelessWidget {
                 subtitle:
                     subtitle?.isNotEmpty ?? false ? Text(subtitle!) : null,
                 onTap: url?.isNotEmpty ?? false
-                    ? () async {
-                        if (await canLaunchUrl(Uri.parse(url!))) {
-                          await launchUrl(Uri.parse(url));
-                        } else {
-                          throw 'Could not launch $url';
-                        }
-                      }
+                    ? () => ref.read(linkServiceProvider).launchLink(url!)
                     : null,
               );
             },
@@ -102,8 +97,8 @@ Widget divider(
       child: Container(
         height: 0.0,
         decoration: BoxDecoration(
-          border: Border(
-            bottom: Divider.createBorderSide(context, color: color, width: 2),
+          Border: Border(
+            Bottom: Divider.createBorderSide(context, color: color, width: 2),
           ),
         ),
       ),


### PR DESCRIPTION
Closes #49

Refactored `AboutPage` from a `StatelessWidget` to a Riverpod `ConsumerWidget` and replaced the duplicate inline URL launching logic with the existing `linkServiceProvider`. This removes raw dependencies on `url_launcher` from the UI layer and unifies the app's link handling.